### PR TITLE
setup matrix workflow and separate combine job

### DIFF
--- a/.github/workflows/update_precompute.yaml
+++ b/.github/workflows/update_precompute.yaml
@@ -3,15 +3,64 @@ on:
     # runs every day at 10:00 AM UTC in jan, feb, aug-dec
     - cron:  '0 10 * 1,2,9-12 *'
   workflow_dispatch:
+    inputs:
+      season_rebuild:
+        description: 'Rebuild Season (9999 defaults to latest season)'
+        required: false
+        default: 9999
+        type: number
+      full_rebuild:
+        description: 'Full Rebuild (overwrites above season)'
+        required: true
+        default: false
+        type: boolean
 
 name: update-computed-numbers
 
 jobs:
-  update:
-    name: Update Computed Numbers
+  setup:
     runs-on: ubuntu-latest
+    name: setup
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FULL_REBUILD: ${{ inputs.full_rebuild || false }}
+      SEASON_REBUILD: ${{ inputs.season_rebuild || 9999 }}
+    outputs:
+      seasons: ${{ steps.query_seasons.outputs.seasons }}
+    steps:
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: nflverse/nflverse-workflows
+
+      - id: query_seasons
+        name: Query Seasons
+        run: |
+          if [ $FULL_REBUILD == true ]
+          then
+            seasons=$( Rscript -e 'nflverse.workflows::get_season_range(2014)' )
+          elif [ $SEASON_REBUILD == 9999 ]
+          then
+            seasons=$( Rscript -e 'nflverse.workflows::get_current_season()' )
+          else
+            seasons=${{ env.SEASON_REBUILD }}
+          fi
+          echo "seasons=$seasons" >> "$GITHUB_OUTPUT"
+
+  update_seasons:
+    needs: setup
+    name: Update ${{ matrix.season }} Numbers
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        season: ${{ fromJson(needs.setup.outputs.seasons) }}
+        type: ["season"]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NFLVERSE_UPDATE_SEASON: ${{ matrix.season }}
+      NFLVERSE_UPDATE_TYPE: ${{ matrix.type }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,6 +75,32 @@ jobs:
             local::.,
             callr
           extra-packages: |
+            nflverse/nflverse-data
+            nflverse/nflreadr
+
+      - name: Run update script
+        run: Rscript -e 'source("data-raw/_save_computed_numbers.R")'
+
+  combine_seasons:
+    needs: [setup, update_seasons]
+    name: Combine Computed Numbers
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NFLVERSE_UPDATE_TYPE: "combine"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          extra-repositories: 'https://nflverse.r-universe.dev'
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
             nflverse/nflverse-data
             nflverse/nflreadr
 

--- a/.github/workflows/update_precompute.yaml
+++ b/.github/workflows/update_precompute.yaml
@@ -44,7 +44,7 @@ jobs:
           then
             seasons=$( Rscript -e 'nflverse.workflows::get_current_season()' )
           else
-            seasons=$( printf $SEASON_REBUILD )
+            seasons="[$SEASON_REBUILD]"
           fi
           echo "seasons=$seasons" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/update_precompute.yaml
+++ b/.github/workflows/update_precompute.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       season_rebuild:
-        description: 'Rebuild Season (9999 defaults to latest season)'
+        description: 'Rebuild Season (9999 defaults to latest season). Do multiple seasons comma separated, e.g. 2017,2019,2021'
         required: false
         default: 9999
         type: number

--- a/.github/workflows/update_precompute.yaml
+++ b/.github/workflows/update_precompute.yaml
@@ -44,7 +44,7 @@ jobs:
           then
             seasons=$( Rscript -e 'nflverse.workflows::get_current_season()' )
           else
-            seasons=${{ env.SEASON_REBUILD }}
+            seasons=$( printf $SEASON_REBUILD )
           fi
           echo "seasons=$seasons" >> "$GITHUB_OUTPUT"
 

--- a/data-raw/_save_computed_numbers.R
+++ b/data-raw/_save_computed_numbers.R
@@ -1,17 +1,46 @@
-pbp <- nfl4th::load_4th_pbp(seq(2014, nflreadr::most_recent_season()))
+season <- Sys.getenv("NFLVERSE_UPDATE_SEASON", unset = NA_character_) |> as.integer()
+type <- Sys.getenv("NFLVERSE_UPDATE_TYPE", unset = NA_character_)
+type <- rlang::arg_match0(type, c("season", "combine"))
 
-condensed <- pbp |>
-  dplyr::filter(!is.na(go_boost)) |>
-  dplyr::select(
-    game_id, play_id, go_boost, go_wp, punt_wp, fg_wp
+if (type == "season"){
+
+  pbp <- nfl4th::load_4th_pbp(season)
+
+  condensed <- pbp |>
+    dplyr::filter(!is.na(go_boost)) |>
+    dplyr::select(
+      game_id, play_id, go_boost, go_wp, punt_wp, fg_wp
+    )
+
+  nflversedata::nflverse_save(
+    condensed,
+    file_name = paste0("pre_computed_go_boost_", season),
+    nflverse_type = "nfl4th go boost",
+    file_types = "rds",
+    repo = "nflverse/nfl4th",
+    release_tag = "nfl4th_infrastructure"
   )
 
-nflversedata::nflverse_save(
-  condensed,
-  file_name = "pre_computed_go_boost",
-  nflverse_type = "nfl4th go boost",
-  file_types = "rds",
-  repo = "nflverse/nfl4th",
-  release_tag = "nfl4th_infrastructure"
-)
+} else if (type == "combine") {
+
+  combined <- purrr::map(
+    seq(2014, nflreadr::most_recent_season()),
+    function(s){
+      glue::glue("https://github.com/nflverse/nfl4th/releases/download/nfl4th_infrastructure/pre_computed_go_boost_{s}.rds") |>
+        nflreadr::rds_from_url()
+    },
+    .progress = TRUE
+  ) |>
+    purrr::list_rbind()
+
+  nflversedata::nflverse_save(
+    combined,
+    file_name = "pre_computed_go_boost",
+    nflverse_type = "nfl4th go boost",
+    file_types = "rds",
+    repo = "nflverse/nfl4th",
+    release_tag = "nfl4th_infrastructure"
+  )
+
+}
 


### PR DESCRIPTION
This updates the workflow for the data update to run current season only and pull older seasons from release. It also allows to trigger a full rebuild.

This will improve the efficiency of the update workflow